### PR TITLE
Develop -> Main Release

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -35,8 +35,13 @@ class HandleInertiaRequests extends Middleware
      */
     public function share(Request $request): array
     {
+        // Acts globally only pass the data you need!
         return array_merge(parent::share($request), [
-            //
+            'auth' => [
+                'user' => [
+                    'username' => 'John Doe' // Get with api in real world scenario
+                ]
+            ]
         ]);
     }
 }

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -1,18 +1,13 @@
 <template>
-    <Layout class="w-full">
-        <div class="px-5 mt-4">
-            <h1 class="text-xl tracking-wider mb-4">Hello</h1>
-        </div>
-    </Layout>
+    <div class="px-5 mt-4">
+        <h1 class="text-xl tracking-wider mb-4">Hello</h1>
+    </div>
 </template>
 
 <script>
 
-import Layout from "../Shared/Layout.vue";
-
 export default {
     name: "Home",
-    components: {Layout}
 }
 </script>
 

--- a/resources/js/Pages/Settings.vue
+++ b/resources/js/Pages/Settings.vue
@@ -1,18 +1,13 @@
 <template>
-    <Layout class="w-full">
-        <div class="px-5 mt-4">
-            <h1 class="text-xl tracking-wider mb-4">Settings</h1>
-        </div>
-    </Layout>
+    <div class="px-5 mt-4">
+        <h1 class="text-xl tracking-wider mb-4">Settings</h1>
+    </div>
 </template>
 
 <script>
-import Nav from "../Shared/Nav.vue";
-import Layout from "../Shared/Layout.vue";
 
 export default {
     name: "Settings",
-    components: {Layout, Nav}
 }
 </script>
 

--- a/resources/js/Pages/Users.vue
+++ b/resources/js/Pages/Users.vue
@@ -1,19 +1,15 @@
 <template>
-    <Layout class="w-full">
-        <div class="px-5 mt-4">
-            <h1 class="text-xl tracking-wider mb-4">Users</h1>
-        </div>
-    </Layout>
+    <div class="px-5 mt-4">
+        <h1 class="text-xl tracking-wider mb-4">Users</h1>
+    </div>
 </template>
 
 <script>
-import Nav from "../Shared/Nav.vue";
-import Layout from "../Shared/Layout.vue";
 
 export default {
     name: "Users",
-    components: {Layout, Nav}
 }
+
 </script>
 
 <style scoped>

--- a/resources/js/Shared/Layout.vue
+++ b/resources/js/Shared/Layout.vue
@@ -2,6 +2,7 @@
     <header class="flex w-full">
         <Nav>
             <h1 class="font-bold text-lg">My App</h1>
+            <p>Welcome back {{ $page.props.auth.user.username }}</p>
         </Nav>
     </header>
     <div class="max-w-3xl mx-auto">
@@ -10,11 +11,9 @@
 </template>
 
 <script>
-import Nav from "./Nav.vue";
 
 export default {
     name: "Layout",
-    components: {Nav}
 }
 </script>
 

--- a/resources/js/Shared/Nav.vue
+++ b/resources/js/Shared/Nav.vue
@@ -1,6 +1,6 @@
 <template>
     <nav class="p-2 bg-gray-200 w-full">
-        <ul class="flex justify-between p-4">
+        <ul class="flex justify-around p-4">
             <slot/>
             <li class="">
                 <Link :class="{'underline font-bold': $page.component === 'Home'}" href="/">

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,18 +1,27 @@
 import {createApp, h} from 'vue';
-import {createInertiaApp} from '@inertiajs/inertia-vue3';
+import {createInertiaApp, Link} from '@inertiajs/inertia-vue3';
 import {resolvePageComponent} from 'laravel-vite-plugin/inertia-helpers';
-import {InertiaProgress} from "@inertiajs/progress";
+import {InertiaProgress} from '@inertiajs/progress';
+
+import Layout from './Shared/Layout.vue';
+import Nav from './Shared/Nav.vue';
 
 createInertiaApp({
-    resolve: (name) => resolvePageComponent(`./Pages/${name}.vue`, import.meta.glob('./Pages/**/*.vue')),
+    resolve: async (name) => {
+        const page = await resolvePageComponent(`./Pages/${name}.vue`, import.meta.glob('./Pages/**/*.vue'));
+        page.default.layout = page.default.layout ?? Layout;
+        return page;
+    },
     setup({el, App, props, plugin}) {
         createApp({render: () => h(App, props)})
             .use(plugin)
-            .mount(el)
+            .component('Link', Link)
+            .component('Nav', Nav)
+            .mount(el);
     },
 });
 
 InertiaProgress.init({
     color: 'red',
-    showSpinner: true
+    showSpinner: true,
 });


### PR DESCRIPTION
# This PR Contains
## Update to inertia boiler plate

[Example of how to pass global props to any component - only pass esse…](https://github.com/Web-Dev-Carl/inertia-boilerplate/commit/558059b0eed6b0d5b431fc6e7de507186695db05) 

(https://github.com/Web-Dev-Carl/inertia-boilerplate/commits?author=Web-Dev-Carl)
[Tidy up](https://github.com/Web-Dev-Carl/inertia-boilerplate/commit/33a3fd4c6755d80aeecc73211dfdedcf26bedbe4)

(https://github.com/Web-Dev-Carl/inertia-boilerplate/commits?author=Web-Dev-Carl)
[Global Component Registration](https://github.com/Web-Dev-Carl/inertia-boilerplate/commit/3c2b4c14e5fae0e1126df97d46a1c8991cfac9cc)

(https://github.com/Web-Dev-Carl/inertia-boilerplate/commits?author=Web-Dev-Carl)
[Component registration - slimming down component imports by using the…](https://github.com/Web-Dev-Carl/inertia-boilerplate/commit/38ca1ad14387203a9f8b78963f43945f63386424) 

(https://github.com/Web-Dev-Carl/inertia-boilerplate/commits?author=Web-Dev-Carl)
[Persistant layouts - no need to add layout component to page when lay…](https://github.com/Web-Dev-Carl/inertia-boilerplate/commit/333e3f4bc395111a6e32c3974885360150574b80) 

(https://github.com/Web-Dev-Carl/inertia-boilerplate/commits?author=Web-Dev-Carl)
[Persistant layouts - no need to add layout component to page when lay…](https://github.com/Web-Dev-Carl/inertia-boilerplate/commit/362e1835b3d2c9919f7dabfc32c758c6d0b2fb0b) 

(https://github.com/Web-Dev-Carl/inertia-boilerplate/commits?author=Web-Dev-Carl)
[Default Layouts - a default layout that dont have to be set on all pa…](https://github.com/Web-Dev-Carl/inertia-boilerplate/commit/719a6e45c732a469245d1b475271dd7d5e982026) 
